### PR TITLE
python 2.5 support

### DIFF
--- a/diesel/hub.py
+++ b/diesel/hub.py
@@ -2,7 +2,10 @@
 '''An event hub that supports sockets and timers, based
 on Python 2.6's select & epoll support.
 '''
-import select
+try:
+    import select26 as select
+except ImportError:
+    import select
 
 from collections import deque
 from time import time

--- a/diesel/protocols/mongodb.py
+++ b/diesel/protocols/mongodb.py
@@ -1,6 +1,9 @@
 # vim:ts=4:sw=4:expandtab
 """A mongodb client library for Diesel"""
 
+# needed to make diesel work with python 2.5
+from __future__ import with_statement
+
 import itertools
 import struct
 from collections import deque

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,13 @@
 import sys 
-assert sys.version_info >= (2, 6), \
-"Diesel requires python 2.6 (or greater 2.X release)"
+assert sys.version_info >= (2, 5), \
+"Diesel requires python 2.5 (or greater 2.X release)"
 
 from setuptools import setup
+
+additional_requires = []
+if sys.version_info <= (2, 6):
+	additional_requires.append('select26')
+	print 'additional:', additional_requires
 
 VERSION = "1.9.7b"
 
@@ -25,5 +30,5 @@ for building web applications.
     download_url="http://download.dieselweb.org/diesel-%s.tar.gz" % VERSION, 
     packages=["diesel", "diesel.protocols", "diesel.util"],
     scripts=["examples/dhttpd"],
-    install_requires=["greenlet", "pyopenssl"],
+    install_requires=(["greenlet", "pyopenssl"] + additional_requires),
     )


### PR DESCRIPTION
Hi,
Since both `with` and select.epoll are available in python 2.5 through additional modules / **future**, you might want to include it.
