### PR TITLE
Don't override the TCP Loop send() function, and allow UDP defaults.

### DIFF
--- a/diesel/app.py
+++ b/diesel/app.py
@@ -222,6 +222,7 @@ class UDPService(Service):
             raise
 
         l = UDPLoop(self.connection_handler, data, addr)
+        l.set_udp_default((addr[0], self.port))
         runtime.current_app.add_loop(l)
 
 def quickstart(*args):

--- a/examples/udp_echo.py
+++ b/examples/udp_echo.py
@@ -1,10 +1,10 @@
 # vim:ts=4:sw=4:expandtab
 '''Simple udp echo server.
 '''
-from diesel import Application, UDPService, send
+from diesel import Application, UDPService, sendto
 
 def hi_server(data, addr):
-    send("you said %s" % data, addr=addr[0], port=8014)
+    sendto("you said %s" % data, (addr[0], 8014))
 
 app = Application()
 app.add_service(UDPService(hi_server, 8013))

--- a/examples/udp_echo_client.py
+++ b/examples/udp_echo_client.py
@@ -2,11 +2,11 @@
 '''Simple udp echo client.
 '''
 import time
-from diesel import Application, UDPService, UDPLoop, send, sleep
+from diesel import Application, UDPService, UDPLoop, sendto, sleep
 
 def hi_loop():
     while 1:
-        send("whatup?", addr='localhost', port=8013)
+        sendto("whatup?")
         print time.ctime(), "sent message to server"
         sleep(3)
 
@@ -15,5 +15,7 @@ def hi_client(data, addr):
 
 app = Application()
 app.add_service(UDPService(hi_client, 8014))
-app.add_loop(UDPLoop(hi_loop))
+loop = UDPLoop(hi_loop)
+loop.set_udp_default(('localhost', 8013))
+app.add_loop(loop)
 app.run()


### PR DESCRIPTION
A UDPLoop now only implements the sendto() function, for POSIX similarity.
This allows UDPLoops to perform TCP connections, since send() isn't
overridden. This commit also allows a UDPLoop to be assigned a default
address and port so sendto() can be called with a single data argument.
