### PR TITLE
Streaming WSGI

### DIFF
--- a/diesel/protocols/http.py
+++ b/diesel/protocols/http.py
@@ -232,7 +232,10 @@ def http_response(req, code, heads, body):
     req.version, code, status_strings.get(code, "Unknown Status"),
     heads.format()))
     if body:
-        send(body)
+        if isinstance(body, basestring):
+            body = [body]
+        for part in body:
+            send(body)
     if close:
         return False
     return True


### PR DESCRIPTION
This change adds efficient streaming support to diesel2's WSGI implementation. The previous version consumed the result from the `wsgi_callable` and stuffed it into a list. This version streams the parts of the result out using `send`.

There are a couple cases where the result is not streamed. First, if there is no `Content-Length` header supplied. Second, if the entire `wsgi_callable` is a generator it has to be flattened to set headers and such.

Just make sure your `wsgi_callable` _returns_ a generator, and you can stream.
