### PR TITLE
Allow specifying context

### DIFF
--- a/diesel/protocols/zeromq.py
+++ b/diesel/protocols/zeromq.py
@@ -3,12 +3,11 @@ from errno import EAGAIN
 from collections import deque
 from diesel.util.queue import Queue
 
-zctx = zmq.Context()
-
 class DieselZMQSocket(object):
     '''Integrate zmq's super fast event loop with ours.
     '''
-    def __init__(self, socket, bind=None, connect=None):
+    def __init__(self, socket, bind=None, connect=None, context=None):
+        self.zctx = context or zmq.Context.instance()
         self.socket = socket
         from diesel.runtime import current_app
         from diesel.hub import IntWrap


### PR DESCRIPTION
Having a zmq Context being created as import time side-effect can cause problems if we try to use the context across processes or threads, like uncatchable C asserts which can halt the interpreter. 

Letting us specify the context as an optional argument and falling back on the global instance is a remedy for the issue. See: http://zeromq.github.com/pyzmq/api/generated/zmq.core.context.html#zmq.core.context.Context.instance
