### PR TITLE
Fix cgi_name

### DIFF
--- a/diesel/protocols/http.py
+++ b/diesel/protocols/http.py
@@ -149,7 +149,12 @@ class TimeoutHandler(object):
         raise HttpRequestTimeout()
 
 def cgi_name(n):
-    return 'HTTP_' + n.upper().replace('-', '_')
+    if n in ('Content-Type', 'Content-Length'):
+        # Certain headers are defined in CGI as not having an HTTP
+        # prefix.
+        return n.upper().replace('-', '_')
+    else:
+        return 'HTTP_' + n.upper().replace('-', '_')
 
 class HttpClient(Client):
     '''An HttpClient instance that issues 1.1 requests,


### PR DESCRIPTION
The CGI reference (and therefore WSGI) defines Content-Type and
Content-Length as headers that need to be put into the environment sans
their HTTP_ prefix decorator.
