### PR TITLE
Fair Handling Of EarlyValues

### DIFF
--- a/diesel/core.py
+++ b/diesel/core.py
@@ -287,7 +287,7 @@ class Loop(object):
             for w in waits:
                 v = self._wait(w, marked_cb(w))
                 if type(v) is EarlyValue:
-                    #self.clear_pending_events()
+                    self.clear_pending_events()
                     self.reschedule_with_this_value((w, v.val))
                     break
         return self.dispatch()


### PR DESCRIPTION
If a Waiter produces an EarlyValue, the Loop requests the hub to call it back later with that value, and then hands control back to the hub. This allows for fair interleaving of green threads when values are ready early. It also works around a previous solution that caused incorrect event ordering. In addition to being correct, it is ~20% faster than the previous solution.
