### PR TITLE
WebSockets protocol fixes and improvements.

### DIFF
--- a/diesel/protocols/websockets.py
+++ b/diesel/protocols/websockets.py
@@ -1,8 +1,18 @@
+"""A WebSocket protocol implementation for diesel.
+
+Implements much of RFC 6455 (http://tools.ietf.org/html/rfc6455) and enough
+of hybi-00 to support Safari 5.0.1+.
+
+Not implemented:
+    * PING/PONG.
+    * Extension support.
+
+"""
 from .http import HttpServer, Response
 from diesel.util.queue import Queue
 from diesel import fork, until, receive, first, ConnectionClosed, send
 from simplejson import dumps, loads, JSONDecodeError
-import cgi, hashlib
+import hashlib
 from struct import pack, unpack
 from base64 import b64encode
 from array import array
@@ -17,11 +27,37 @@ class WebSocketServer(HttpServer):
     GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 
     def __init__(self, web_handler, web_socket_handler):
+        """Creates a WebSocket server.
+
+        The `web_handler` is used for non-WebSocket HTTP requests. It should
+        be a callable that accepts a `Request` and returns a `Response`.
+
+        The `web_socket_handler` will be called with three arguments: a
+        `Request` instance, an input `Queue` and an output `Queue`. The input
+        queue is where messages from the client will be received. Anything
+        put in the output queue will be sent on to the client.
+
+        All values passed to and from the queues MUST be dictionaries, or
+        something that is JSON serializable. The one special case is the
+        WebSocketDisconnect object that can arrive on the input queue if
+        the client is closing the connection.
+
+        """
         self.web_handler = web_handler
         self.web_socket_handler = web_socket_handler
         HttpServer.__init__(self, self.do_upgrade)
 
     def do_upgrade(self, req):
+        """Handles the WebSocket handshake.
+
+        Processes the `Request` instance `req` and returns a `Response`.
+
+        Adds the WebSocket messaging protocol handler
+        (`WebSocketServer.websocket_protocol`) to the `Response` object as
+        `new_protocol`. That gets called by the underlying HttpServer when it
+        sees a 101 Switching Protocols response.
+
+        """
         if req.headers.get('Upgrade', '').lower() != 'websocket':
             return self.web_handler(req)
 
@@ -63,6 +99,7 @@ class WebSocketServer(HttpServer):
             handshake_finish = hashlib.md5(final).digest()
         else:
             assert 0, "Unsupported WebSocket handshake."
+        req.rfc_handshake = not bool(handshake_finish)
 
         if protocol:
             headers['Sec-WebSocket-Protocol'] = protocol
@@ -72,9 +109,18 @@ class WebSocketServer(HttpServer):
                 status=101,
                 headers=headers,
                 )
+        resp.new_protocol = self.websocket_protocol
 
-        self.send_response(resp)
+        return resp
 
+    def websocket_protocol(self, req):
+        """Runs the WebSocket protocol after the handshake is complete.
+
+        Creates two `Queue` instances for incoming and outgoing messages and
+        passes them to the `web_socket_handler` that was supplied to the
+        `WebSocketServer` constructor.
+
+        """
         inq = Queue()
         outq = Queue()
 
@@ -82,9 +128,9 @@ class WebSocketServer(HttpServer):
             self.web_socket_handler(req, inq, outq)
             outq.put(WebSocketDisconnect())
 
-        fork(wrap, req._get_current_object(), inq, outq)
+        handler_loop = fork(wrap, req, inq, outq)
 
-        if not handshake_finish:
+        if req.rfc_handshake:
             handle_frames = self.handle_rfc_6455_frames
         else:
             handle_frames = self.handle_non_rfc_frames
@@ -92,11 +138,12 @@ class WebSocketServer(HttpServer):
         try:
             handle_frames(inq, outq)
         except ConnectionClosed:
-            inq.put(WebSocketDisconnect())
+            if handler_loop.running:
+                inq.put(WebSocketDisconnect())
             raise
-            #raise ConnectionClosed("remote disconnected")
 
     def handle_rfc_6455_frames(self, inq, outq):
+        disconnecting = False
         while True:
             typ, val = first(receive=2, waits=[outq])
             if typ == 'receive':
@@ -110,16 +157,21 @@ class WebSocketServer(HttpServer):
 
                 if opcode == 8:
                     inq.put(WebSocketDisconnect())
-                else:
-                    assert opcode == 1, "Currently only opcode 1 is supported (opcode=%s)" % opcode
-                    length = b2 & 0x7f
-                    if length == 126:
-                        length = unpack('>H', receive(2))[0]
-                    elif length == 127:
-                        length = unpack('>L', receive(8))[0]
+                    if disconnecting:
+                        break
+                    disconnecting = True
+                assert opcode in [1,8], "Currently only opcodes 1 & 8 are supported (opcode=%s)" % opcode
+                length = b2 & 0x7f
+                if length == 126:
+                    length = unpack('>H', receive(2))[0]
+                elif length == 127:
+                    length = unpack('>L', receive(8))[0]
 
-                    mask = unpack('>BBBB', receive(4))
+                mask = unpack('>BBBB', receive(4))
+                if length:
                     payload = array('B', receive(length))
+                    if disconnecting:
+                        continue
                     for i in xrange(len(payload)):
                         payload[i] ^= mask[i % 4]
 
@@ -132,7 +184,9 @@ class WebSocketServer(HttpServer):
                 if type(val) is WebSocketDisconnect:
                     b1 = 0x80 | (8 & 0x0f) # FIN + opcode
                     send(pack('>BB', b1, 0))
-                    break
+                    if disconnecting:
+                        break
+                    disconnecting = True
                 else:
                     payload = dumps(val)
 
@@ -146,7 +200,7 @@ class WebSocketServer(HttpServer):
                     elif payload_len >= 65536:
                         header = pack('>BBQ', b1, 127, payload_len)
 
-                send(header + payload)
+                    send(header + payload)
 
     def handle_non_rfc_frames(self, inq, outq):
         while True:
@@ -156,6 +210,7 @@ class WebSocketServer(HttpServer):
                 val = until('\xff')[:-1]
                 if val == '':
                     inq.put(WebSocketDisconnect())
+                    break
                 else:
                     try:
                         data = loads(val)

--- a/diesel/web.py
+++ b/diesel/web.py
@@ -96,7 +96,7 @@ class DieselFlask(Flask):
         ws = WebSocketServer(no_web, f)
         def ws_call(*args, **kw):
             assert not args and not kw, "No arguments allowed to websocket routes"
-            ws.do_upgrade(request)
+            return ws.do_upgrade(request)
         return ws_call
 
     def run(self, *args, **params):


### PR DESCRIPTION
Fixes to disconnect behavior. Clients can now cleanly
disconnect/reconnect and exceptions due to data being left in the
receive buffers are gone.

Also changes the way WebSockets integrate internally. The HttpServer is
now generally aware of "101 Switching Protocols" responses and will
attempt to call a `new_protocol` callable on the Response object. This
works around some errors that were happening due to Flask not seeing a
response on a disconnect (do to the `do_upgrade` function returning
None).

Many thanks to Sébastien Arnaud for discovering these bugs and for the
proper two-phase disconnect code that he contributed (and is included
here).
