### PR TITLE
source_ip for Client and UDPClient and source IP resolution -- Client improvements based on dowski's PR

### DIFF
--- a/diesel/resolver.py
+++ b/diesel/resolver.py
@@ -5,6 +5,7 @@ a cache.
 import os
 import random
 import time
+import socket
 from diesel.protocols.DNS import DNSClient, NotFound, Timeout
 from diesel.util.pool import ConnectionPool
 from diesel.util.lock import synchronized
@@ -41,6 +42,15 @@ def resolve_dns_name(name):
 
     Keep a cache.
     '''
+
+    # Is name an IP address?
+    try:
+        socket.inet_pton(socket.AF_INET, name)
+        return name
+    except socket.error:
+        # Not a valid IP address resolve it
+        pass
+
     if name in hosts:
         return hosts[name]
 


### PR DESCRIPTION
Based on reject pull request of dowski ( https://github.com/jamwt/diesel/pull/65/files )

(basically refactoring of dowski's PR)

Determination of IP/name is now done inside resolver.py as requested by jamwt

source_ip specification is now possible for Client as well as UDPClient. 
Having it inside UDPClient was a necessity as _setup_socket in UDPClient is called using code from Client's __init__
