### PR TITLE
setup.py: Add pyev to additional_requires if no select.epoll available

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-import sys, os
+import select, sys, os
 assert sys.version_info >= (2, 6), \
 "Diesel requires python 2.6 (or greater 2.X release)"
 
@@ -8,6 +8,11 @@ if os.system("which palmc > /dev/null 2>&1") == 0:
     os.system("palmc ./diesel/protocols ./diesel/protocols")
 
 additional_requires = []
+
+if (os.environ.get('DIESEL_LIBEV') or
+    os.environ.get('DIESEL_NO_EPOLL') or
+    not hasattr(select, 'epoll')):
+    additional_requires.append('pyev')
 
 VERSION = "3.0.21"
 


### PR DESCRIPTION
Automatically install `pyev` if it's needed
