### PR TITLE
setup.py: Add dependency on "palm"; needed by diesel.convoy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,5 +58,6 @@ Other bundled protocols include MongoDB, Riak, and Redis client libraries.
         "flask",
         "http-parser >= 0.7.12",
         "dnspython",
+        "palm",
     ] + additional_requires),
     )


### PR DESCRIPTION
It seems that `diesel.convoy` needs the `palm` module.

Without this change:

```
(py27.venv)marca@marca-mac:~/dev/git-repos/diesel$ python -c 'import diesel.convoy'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "diesel/convoy/__init__.py", line 6, in <module>
    from palm.palm import ProtoBase
ImportError: No module named palm.palm
```

With it:

```
(py27.venv)marca@marca-mac:~/dev/git-repos/diesel$ python setup.py develop
...
Searching for palm
Reading https://pypi.python.org/simple/palm/
Best match: palm 0.1.7
Downloading https://pypi.python.org/packages/source/p/palm/palm-0.1.7.tar.gz#md5=f49942ae4746191e73e0935c4c31c6ae
Processing palm-0.1.7.tar.gz
...

(py27.venv)marca@marca-mac:~/dev/git-repos/diesel$ python -c 'import diesel.convoy'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "diesel/convoy/__init__.py", line 11, in <module>
    from diesel.logmod import LOGLVL_DEBUG
ImportError: cannot import name LOGLVL_DEBUG
```

but that's another problem (see #87).
