### PR TITLE
Handle fact that pyev.version() doesn't seem to exist in pyev==0.9.0

### DIFF
--- a/diesel/hub.py
+++ b/diesel/hub.py
@@ -305,7 +305,7 @@ class LibEvHub(AbstractEventHub):
     @property
     def describe(self):
         return "libev/pyev (%s/%s) backend=%s" % (
-                pyev.version() + ({
+                self._pyev_version() + ({
                     1  : "select()",
                     2  : "poll()",
                     4  : "epoll()",
@@ -313,6 +313,12 @@ class LibEvHub(AbstractEventHub):
                     16 : "/dev/poll",
                     32 : "event ports",
                     }.get(self._ev_loop.backend, "UNKNOWN"),))
+
+    def _pyev_version(self):
+        if hasattr(pyev, 'version'):
+            return pyev.version()
+        else:
+            return pyev.abi_version()
 
     def handle_events(self):
         '''Run one pass of event handling.


### PR DESCRIPTION
Without this PR on a Mac (so I need `pyev` because I don't have `select.epoll`):

```
(py27.venv)marca@marca-mac:~/dev/git-repos/diesel$ make -C tests
dnosetests unit/ integration/
Traceback (most recent call last):
  File "/Users/marca/dev/git-repos/diesel/py27.venv/bin/dnosetests", line 9, in <module>
    load_entry_point('diesel==3.0.21', 'console_scripts', 'dnosetests')()
  File "/Users/marca/dev/git-repos/diesel/diesel/dnosetests.py", line 17, in main
    diesel.quickstart(nose.main)
  File "/Users/marca/dev/git-repos/diesel/diesel/app.py", line 288, in quickstart
    app.run()
  File "/Users/marca/dev/git-repos/diesel/diesel/app.py", line 59, in run
    log.warning('Starting diesel <{0}>', self.hub.describe)
  File "/Users/marca/dev/git-repos/diesel/diesel/hub.py", line 308, in describe
    pyev.version() + ({
AttributeError: 'module' object has no attribute 'version'
make: *** [test-core] Error 1
```

With this patch:

```
(py27.venv)marca@marca-mac:~/dev/git-repos/diesel$ make -C tests
dnosetests unit/ integration/
...................................................
----------------------------------------------------------------------
Ran 51 tests in 8.340s

OK
```
