### PR TITLE
Add tox.ini for tox (http://tox.testrun.org/)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py26, py27
+
+[testenv]
+deps =
+    nose
+commands =
+    dnosetests tests/unit/ tests/integration/


### PR DESCRIPTION
[Tox](http://tox.testrun.org/) is for testing across multiple Python versions and virtualenvs.

Example usage:

```
vagrant@lucid64:~/dev/git-repos/diesel$ tox
GLOB sdist-make: /home/vagrant/dev/git-repos/diesel/setup.py
py26 create: /home/vagrant/dev/git-repos/diesel/.tox/py26
py26 installdeps: nose
py26 sdist-inst: /home/vagrant/dev/git-repos/diesel/.tox/dist/diesel-3.0.21.zip
py26 runtests: commands[0]
...................................................
----------------------------------------------------------------------
Ran 51 tests in 8.212s

OK
py27 create: /home/vagrant/dev/git-repos/diesel/.tox/py27
py27 installdeps: nose
py27 sdist-inst: /home/vagrant/dev/git-repos/diesel/.tox/dist/diesel-3.0.21.zip
py27 runtests: commands[0]
...................................................
----------------------------------------------------------------------
Ran 51 tests in 8.184s

OK
_________________________________________________________________________________________________________________________________________________________ summary __________________________________________________________________________________________________________________________________________________________
  py26: commands succeeded
  py27: commands succeeded
  congratulations :)
```
