### PR TITLE
Add "from __future__ import absolute_import" to diesel/protocols/DNS.py

### DIFF
--- a/diesel/protocols/DNS.py
+++ b/diesel/protocols/DNS.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import time
 from collections import deque
 


### PR DESCRIPTION
so that imports from `dns` don't grab from `DNS.py` itself on case-insensitive filesystems (like HFS filesystems by default on Macs).

Without this patch, I get the following when working in a directory of an Ubuntu VirtualBox VM that is mounted from an HFS volume on my Mac:

``` python
(py26.venv)vagrant@lucid64:/opt/webapp/memcacheliked$ python
Python 2.6.5 (r265:79063, Oct  1 2012, 22:04:36)
[GCC 4.4.3] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import diesel
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/webapp/memcacheliked/py26.venv/lib/python2.6/site-packages/diesel/__init__.py", line 9, in <module>
    from resolver import resolve_dns_name, DNSResolutionError
  File "/opt/webapp/memcacheliked/py26.venv/lib/python2.6/site-packages/diesel/resolver.py", line 8, in <module>
    from diesel.protocols.DNS import DNSClient, NotFound, Timeout
  File "/opt/webapp/memcacheliked/py26.venv/lib/python2.6/site-packages/diesel/protocols/DNS.py", line 6, in <module>
    from dns.message import make_query, from_wire
  File "/opt/webapp/memcacheliked/py26.venv/lib/python2.6/site-packages/diesel/protocols/dns.py", line 6, in <module>
    from dns.message import make_query, from_wire
ImportError: No module named message
```

With this patch, things work properly:

``` python
(py26.venv)vagrant@lucid64:/opt/webapp/memcacheliked$ python
Python 2.6.5 (r265:79063, Oct  1 2012, 22:04:36)
[GCC 4.4.3] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import diesel
>>> diesel
<module 'diesel' from '/opt/webapp/memcacheliked/py26.venv/lib/python2.6/site-packages/diesel/__init__.pyc'>
>>> import diesel.protocols.DNS
>>> diesel.protocols.DNS
<module 'diesel.protocols.DNS' from '/opt/webapp/memcacheliked/py26.venv/lib/python2.6/site-packages/diesel/protocols/DNS.pyc'>
```
